### PR TITLE
Update Carl and Cantina Security attribution for the named error parameter bug

### DIFF
--- a/src/posts/2026-09-10-misordered-named-parameters-in-require-with-custom-errors-bug.md
+++ b/src/posts/2026-09-10-misordered-named-parameters-in-require-with-custom-errors-bug.md
@@ -7,8 +7,8 @@ author: Solidity Team
 category: Security Alerts
 ---
 
-On February 4, 2026, a bug in the IR-based code generator was reported by Carl from
-[Spearbit](https://spearbit.com/) through the Ethereum Foundation bug bounty program. The
+On February 4, 2026, a bug in the IR-based code generator was reported by [Carl](https://x.com/popular_12345) from
+[Cantina Security](https://cantina.security) through the Ethereum Foundation bug bounty program. The
 bug causes the arguments of a custom error passed to `require` using named-parameter syntax
 to be placed on the stack in call-site order rather than declaration order before they are
 ABI-encoded.

--- a/src/posts/2026-09-10-solidity-0.8.37-release-announcement.md
+++ b/src/posts/2026-09-10-solidity-0.8.37-release-announcement.md
@@ -47,7 +47,7 @@ The encoder would produce a structurally valid payload matching the error signat
 Plain `revert MyError({...})` statements are not affected.
 Only the revert data of a transaction that is already reverting is affected, so the bug has no impact on contract state.
 
-The bug was reported by Carl from [Spearbit](https://spearbit.com/) through the Ethereum Foundation's bug bounty program.
+The bug was reported by [Carl](https://x.com/popular_12345) from [Cantina Security](https://cantina.security) through the Ethereum Foundation's bug bounty program.
 
 Write-up: [Misordered Named Parameters in require with Custom Errors Bug](/blog/2026/09/10/misordered-named-parameters-in-require-with-custom-errors-bug/)
 


### PR DESCRIPTION
Link Carl to his X profile and update the company attribution from Spearbit to Cantina Security in both the named-parameters bug post and the Solidity 0.8.37 release announcement.

Validation: reviewed the Markdown diff; only attribution text and links changed.